### PR TITLE
feat: display last sync time in completion alerts

### DIFF
--- a/omnifocus-jira-sync.omnifocusjs/Resources/jiraCommon.js
+++ b/omnifocus-jira-sync.omnifocusjs/Resources/jiraCommon.js
@@ -252,6 +252,16 @@
     preferences.write(jiraCommon.SETTINGS_KEY, JSON.stringify(settings));
   };
 
+  jiraCommon.formatSyncTime = (isoString) => {
+    const date = new Date(isoString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    return `${year}-${month}-${day} ${hours}:${minutes}`;
+  };
+
   // Credentials management
   jiraCommon.getCredentials = () => {
     const credential = credentials.read(jiraCommon.CREDENTIAL_SERVICE);

--- a/omnifocus-jira-sync.omnifocusjs/Resources/syncJira.js
+++ b/omnifocus-jira-sync.omnifocusjs/Resources/syncJira.js
@@ -71,7 +71,8 @@
       const newSyncTime = new Date().toISOString();
       lib.saveSettings({ ...settings, lastSyncTime: newSyncTime });
 
-      const message = `Sync completed successfully!\n\nCreated: ${stats.created}\nUpdated: ${stats.updated}\nReopened: ${stats.reopened}\nCompleted: ${stats.completed}\nSkipped: ${stats.skipped}`;
+      const previousSync = lastSyncTime ? `Previous sync: ${lib.formatSyncTime(lastSyncTime)}\n` : '';
+      const message = `Sync completed successfully!\n\n${previousSync}Current sync: ${lib.formatSyncTime(newSyncTime)}\n\nCreated: ${stats.created}\nUpdated: ${stats.updated}\nReopened: ${stats.reopened}\nCompleted: ${stats.completed}\nSkipped: ${stats.skipped}`;
       console.log(message);
       new Alert('JIRA Sync Complete', message).show();
     } catch (error) {

--- a/omnifocus-jira-sync.omnifocusjs/Resources/syncJiraFull.js
+++ b/omnifocus-jira-sync.omnifocusjs/Resources/syncJiraFull.js
@@ -102,7 +102,8 @@
       const newSyncTime = new Date().toISOString();
       lib.saveSettings({ ...settings, lastSyncTime: newSyncTime });
 
-      const message = `Full sync completed successfully!\n\nCreated: ${stats.created}\nUpdated: ${stats.updated}\nReopened: ${stats.reopened}\nCompleted: ${stats.completed}\nSkipped: ${stats.skipped}`;
+      const previousSync = lastSyncTime ? `Previous sync: ${lib.formatSyncTime(lastSyncTime)}\n` : '';
+      const message = `Full sync completed successfully!\n\n${previousSync}Current sync: ${lib.formatSyncTime(newSyncTime)}\n\nCreated: ${stats.created}\nUpdated: ${stats.updated}\nReopened: ${stats.reopened}\nCompleted: ${stats.completed}\nSkipped: ${stats.skipped}`;
       console.log(message);
       new Alert('JIRA Full Sync Complete', message).show();
     } catch (error) {


### PR DESCRIPTION
## Summary
- Adds previous and current sync timestamps to the completion alert shown after both incremental and full syncs
- Adds `formatSyncTime()` helper to jiraCommon for consistent timestamp formatting (`YYYY-MM-DD HH:MM`)
- First sync shows only current time; subsequent syncs show both previous and current

Closes #22

## Test plan
- [x] Run incremental sync on first use — alert should show only "Current sync" time
- [x] Run incremental sync again — alert should show both "Previous sync" and "Current sync" times
- [x] Run full sync — verify same timestamp display behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)